### PR TITLE
Added peer directive to interface for unicast clustering

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,11 @@
 vyatta-cluster (0.11.25+vyos2+lithium4) unstable; urgency=low
 
+  * vyatta-cluster: Added peer directive to interface for unicast clustering
+
+ -- Alexander Verhaar <sanderv32@gmail.com> Sun, 17 Jan 2015 10:40:23 +0100
+
+vyatta-cluster (0.11.25+vyos2+lithium4) unstable; urgency=low
+
   * vyatta-cluster: update dh_gencontrol with new development build flag
 
  -- Alex Harpin <development@landsofshadow.co.uk>  Tue, 16 Jun 2015 20:40:44 +0100

--- a/lib/Vyatta/Cluster/Config.pm
+++ b/lib/Vyatta/Cluster/Config.pm
@@ -113,13 +113,13 @@ sub setupOrig {
     $self->{_monitor_dead_itvl} = $config->returnOrigValue("monitor-dead-interval");
 
     $config->setLevel("$level interface");
-    $self->{_interface} = [ $config->listNodes() ];
-    my @interfaces = $config->listNodes();
+    $self->{_interface} = [ $config->listOrigNodes() ];
+    my @interfaces = $config->listOrigNodes();
     my $int;
     my %hash;
     for $int (@interfaces) {
       $config->setLevel("$level interface $int");
-      %hash = ( %hash, $int => $config->returnValue("peer"));
+      %hash = ( %hash, $int => $config->returnOrigValue("peer"));
     }
     $self->{_peers} = \%hash;
 

--- a/lib/Vyatta/Cluster/Config.pm
+++ b/lib/Vyatta/Cluster/Config.pm
@@ -20,6 +20,7 @@ my $HA_WATCHLINK_ID = 'ha';
 
 my %fields = (
     _interface          => undef,
+    _peers              => undef,
     _mcast_grp          => undef,
     _pre_shared         => undef,
     _keepalive_itvl     => undef,
@@ -58,6 +59,17 @@ sub setup {
     $self->{_keepalive_itvl} = $config->returnValue("keepalive-interval");
     $self->{_dead_itvl} = $config->returnValue("dead-interval");
     $self->{_monitor_dead_itvl} = $config->returnValue("monitor-dead-interval");
+
+    $config->setLevel("$level interface");
+    $self->{_interface} = [ $config->listNodes() ];
+    my @interfaces = $config->listNodes();
+    my $int;
+    my %hash;
+    for $int (@interfaces) {
+      $config->setLevel("$level interface $int");
+      %hash = ( %hash, $int => $config->returnValue("peer"));
+    }
+    $self->{_peers} = \%hash;
 
     $config->setLevel("$level group");
     my @groups = $config->listNodes();
@@ -99,6 +111,17 @@ sub setupOrig {
     $self->{_keepalive_itvl} = $config->returnOrigValue("keepalive-interval");
     $self->{_dead_itvl} = $config->returnOrigValue("dead-interval");
     $self->{_monitor_dead_itvl} = $config->returnOrigValue("monitor-dead-interval");
+
+    $config->setLevel("$level interface");
+    $self->{_interface} = [ $config->listNodes() ];
+    my @interfaces = $config->listNodes();
+    my $int;
+    my %hash;
+    for $int (@interfaces) {
+      $config->setLevel("$level interface $int");
+      %hash = ( %hash, $int => $config->returnValue("peer"));
+    }
+    $self->{_peers} = \%hash;
 
     $config->setLevel("$level group");
     my @groups = $config->listOrigNodes();
@@ -206,9 +229,14 @@ sub ha_cf {
     }
     my $interfaces = '';
     foreach my $intf (@{$self->{_interface}}) {
+      if (defined($self->{_peers})) {
+        $interfaces .= "ucast $intf ";
+        $interfaces .= "$self->{_peers}->{$intf}\n";
+      } else {
         $interfaces .= "mcast $intf ";
         $interfaces .= ((defined($self->{_mcast_grp}))?  "$self->{_mcast_grp} " : "$DEFAULT_MCAST_GROUP ");
         $interfaces .= "$DEFAULT_UDP_PORT $DEFAULT_TTL 0\n";
+      }
     }
 
     my $kitvl = $self->{_keepalive_itvl};

--- a/templates-cfg/cluster/interface/node.def
+++ b/templates-cfg/cluster/interface/node.def
@@ -1,3 +1,4 @@
-multi:
+tag:
 type: txt
 help: Interface(s) for sending/receiving heartbeat packets [REQUIRED]
+allowed: ${vyatta_sbindir}/vyatta-interfaces.pl --show all

--- a/templates-cfg/cluster/interface/node.tag/peer/node.def
+++ b/templates-cfg/cluster/interface/node.tag/peer/node.def
@@ -1,0 +1,2 @@
+type: ipv4
+help: IP address of the peer to send the UDP heartbeat too. This disable multicast.


### PR DESCRIPTION
Hi, my colleague Mike also did an attempt to do a pull request for unicast so i'm going to try it also. This time it's done another way by adding a peer directive to the cluster interface:

set cluster interface eth0 peer 1.2.3.4 

This is i think a cleaner way and also a more handy for tab completion :smile: 
Also want to add broadcast to the end of the peer:

set cluster interface eth0 broadcast

to use the heartbeat broadcast feature.
