### PR TITLE
cluster: T4083: Make run dir for heartbeat

### DIFF
--- a/scripts/vyatta-update-cluster.pl
+++ b/scripts/vyatta-update-cluster.pl
@@ -8,6 +8,7 @@ use Vyatta::Cluster::Config;
 my $HA_DIR = "/etc/ha.d";
 my $HA_INIT = "/etc/init.d/heartbeat";
 my $SERVICE_DIR = "/etc/init.d";
+my $RUN_DIR = "/run/heartbeat";
 
 my $conntrackd_service = undef;
 GetOptions("conntrackd_service=s"         => \$conntrackd_service,
@@ -53,7 +54,7 @@ if (defined($err)) {
   exit 1;
 }
 
-my $ret = system("mkdir -p $HA_DIR");
+my $ret = system("mkdir -p $HA_DIR && mkdir -p $RUN_DIR");
 if ($ret >> 8) {
   print STDERR "Error: cannot create $HA_DIR\n";
   exit 1;


### PR DESCRIPTION
In 1.4 cluster/heartbeat can't start because there is a lack of
the directory "/run/heartbeat". Create this directory.

https://phabricator.vyos.net/T4083

```
vyos@r11-roll:~$ show cluster 

  Incomplete command: show cluster

vyos@r11-roll:~$ show cluster status 
=== Status report on primary node r11-roll ===

  Primary r11-roll (this node): Active

  Secondary r12-lts: Down

  Resources [203.0.113.254/24/eth1]:
    Active on primary r11-roll (this node)

vyos@r11-roll:~$ sudo systemctl status heartbeat
● heartbeat.service - Heartbeat High Availability Cluster Communication and Membership
     Loaded: loaded (/lib/systemd/system/heartbeat.service; disabled; vendor preset: enabled)
     Active: active (running) since Mon 2021-12-20 18:57:59 EET; 12min ago
       Docs: man:heartbeat(8)
             http://www.linux-ha.org/wiki/Documentation
   Main PID: 2005 (heartbeat)
      Tasks: 4 (limit: 4695)
     Memory: 8.6M
        CPU: 555ms
     CGroup: /system.slice/heartbeat.service
             ├─2005 heartbeat: master control process
             ├─2028 heartbeat: FIFO reader
             ├─2029 heartbeat: write: mcast eth1
             └─2030 heartbeat: read: mcast eth1

```